### PR TITLE
Defer test key generation in anonymous_tokens tests

### DIFF
--- a/anonymous_tokens/cpp/crypto/rsa_blind_signer_test.cc
+++ b/anonymous_tokens/cpp/crypto/rsa_blind_signer_test.cc
@@ -119,9 +119,6 @@ INSTANTIATE_TEST_SUITE_P(RsaBlindSignerTest, RsaBlindSignerTest,
                                            &GetStrongRsaKeys3072,
                                            &GetStrongRsaKeys4096));
 
-using CreateTestKeyPairFunction =
-    absl::StatusOr<std::pair<RSAPublicKey, RSAPrivateKey>>();
-
 using RsaBlindSignerPublicMetadataTestParams =
     std::tuple<CreateTestKeyPairFunction *,
                /*use_rsa_public_exponent*/ bool>;

--- a/anonymous_tokens/cpp/crypto/rsa_blind_signer_test.cc
+++ b/anonymous_tokens/cpp/crypto/rsa_blind_signer_test.cc
@@ -119,15 +119,18 @@ INSTANTIATE_TEST_SUITE_P(RsaBlindSignerTest, RsaBlindSignerTest,
                                            &GetStrongRsaKeys3072,
                                            &GetStrongRsaKeys4096));
 
+using CreateTestKeyPairFunction =
+    absl::StatusOr<std::pair<RSAPublicKey, RSAPrivateKey>>();
+
 using RsaBlindSignerPublicMetadataTestParams =
-    std::tuple<absl::StatusOr<std::pair<RSAPublicKey, RSAPrivateKey>>,
+    std::tuple<CreateTestKeyPairFunction *,
                /*use_rsa_public_exponent*/ bool>;
 
 class RsaBlindSignerTestWithPublicMetadata
     : public ::testing::TestWithParam<RsaBlindSignerPublicMetadataTestParams> {
  protected:
   void SetUp() override {
-    ANON_TOKENS_ASSERT_OK_AND_ASSIGN(auto keys_pair, std::get<0>(GetParam()));
+    ANON_TOKENS_ASSERT_OK_AND_ASSIGN(auto keys_pair, std::get<0>(GetParam())());
     use_rsa_public_exponent_ = std::get<1>(GetParam());
     public_key_ = std::move(keys_pair.first);
     private_key_ = std::move(keys_pair.second);
@@ -253,8 +256,8 @@ TEST_P(RsaBlindSignerTestWithPublicMetadata,
 INSTANTIATE_TEST_SUITE_P(
     RsaBlindSignerTestWithPublicMetadata, RsaBlindSignerTestWithPublicMetadata,
     ::testing::Combine(
-        ::testing::Values(GetStrongRsaKeys2048(), GetAnotherStrongRsaKeys2048(),
-                          GetStrongRsaKeys3072(), GetStrongRsaKeys4096()),
+        ::testing::Values(&GetStrongRsaKeys2048, &GetAnotherStrongRsaKeys2048,
+                          &GetStrongRsaKeys3072, &GetStrongRsaKeys4096),
         /*use_rsa_public_exponent*/ ::testing::Values(true, false)));
 
 TEST(IetfRsaBlindSignerTest,

--- a/anonymous_tokens/cpp/crypto/rsa_ssa_pss_verifier_test.cc
+++ b/anonymous_tokens/cpp/crypto/rsa_ssa_pss_verifier_test.cc
@@ -161,8 +161,11 @@ TEST(RsaSsaPssVerifierTestWithPublicMetadata,
   }
 }
 
+using CreateTestKeyPairFunction =
+    absl::StatusOr<std::pair<RSAPublicKey, RSAPrivateKey>>();
+
 using RsaSsaPssVerifierPublicMetadataTestParams =
-    std::tuple<absl::StatusOr<std::pair<RSAPublicKey, RSAPrivateKey>>,
+    std::tuple<CreateTestKeyPairFunction *,
                /*use_rsa_public_exponent*/ bool>;
 
 class RsaSsaPssVerifierTestWithPublicMetadata
@@ -170,7 +173,7 @@ class RsaSsaPssVerifierTestWithPublicMetadata
           RsaSsaPssVerifierPublicMetadataTestParams> {
  protected:
   void SetUp() override {
-    ANON_TOKENS_ASSERT_OK_AND_ASSIGN(auto keys_pair, std::get<0>(GetParam()));
+    ANON_TOKENS_ASSERT_OK_AND_ASSIGN(auto keys_pair, std::get<0>(GetParam())());
     use_rsa_public_exponent_ = std::get<1>(GetParam());
     public_key_ = std::move(keys_pair.first);
     ANON_TOKENS_ASSERT_OK_AND_ASSIGN(
@@ -317,8 +320,8 @@ INSTANTIATE_TEST_SUITE_P(
     RsaSsaPssVerifierTestWithPublicMetadata,
     RsaSsaPssVerifierTestWithPublicMetadata,
     ::testing::Combine(
-        ::testing::Values(GetStrongRsaKeys2048(), GetAnotherStrongRsaKeys2048(),
-                          GetStrongRsaKeys3072(), GetStrongRsaKeys4096()),
+        ::testing::Values(&GetStrongRsaKeys2048, &GetAnotherStrongRsaKeys2048,
+                          &GetStrongRsaKeys3072, &GetStrongRsaKeys4096),
         /*use_rsa_public_exponent*/ ::testing::Values(true, false)));
 
 }  // namespace


### PR DESCRIPTION
This change modifies parameterized tests in anonymous_tokens to avoid calling key generation functions like `GetStrongRsaKeys2048()` directly in `INSTANTIATE_TEST_SUITE_P`.

Currently, these functions are invoked every time
`testing::InitGoogleTest()` is called. This results in unnecessary overhead, as the test data is loaded even if the tests are filtered out by `--gtest_filter`.

More critically, this causes a crash in Android multi-process tests. These key generation functions depend on
`PathService::Get(DIR_SRC_TEST_DATA_ROOT)` to load test data. When a new test process is launched via `SpawnMultiProcessTestChild`, `testing::InitGoogleTest()` is called before `InitAndroidTestPaths()`, which sets up the required path providers. This leads to a `NOTREACHED()` failure in `base/base_paths.cc`'s `PathProvider()`.

To fix this, this CL passes function pointers to the key generation methods as the test parameters and defers the actual invocation of these functions until the `SetUp()` method of the test fixture is called. This ensures that the test data is loaded only when the test is actually run, at which point the PathService is correctly initialized.