### PR TITLE
updating client and crypto libraries

### DIFF
--- a/anonymous_tokens/cpp/client/anonymous_tokens_public_key_client.cc
+++ b/anonymous_tokens/cpp/client/anonymous_tokens_public_key_client.cc
@@ -135,7 +135,7 @@ absl::Status ValidityChecksForResponseProcessing(
     // an expiry time should not be returned.
     return absl::InvalidArgumentError("Public Key is not indefinitely valid");
   }
-  absl::optional<absl::Time> public_key_expiry_time = absl::nullopt;
+  absl::optional<absl::Time> public_key_expiry_time = std::nullopt;
   if (public_key_request.has_key_validity_end_time() &&
       public_key.has_expiration_time()) {
     ANON_TOKENS_ASSIGN_OR_RETURN(

--- a/anonymous_tokens/cpp/client/anonymous_tokens_public_key_client_test.cc
+++ b/anonymous_tokens/cpp/client/anonymous_tokens_public_key_client_test.cc
@@ -98,12 +98,12 @@ TEST_F(AnonymousTokensPublicKeysGetClientTest,
   // Create the first request.
   ASSERT_TRUE(client_
                   ->CreateAnonymousTokensPublicKeysGetRequest(
-                      TEST_USE_CASE, 1, absl::Now(), absl::nullopt)
+                      TEST_USE_CASE, 1, absl::Now(), std::nullopt)
                   .ok());
   // Second request will err.
   absl::StatusOr<AnonymousTokensPublicKeysGetRequest> request =
       client_->CreateAnonymousTokensPublicKeysGetRequest(
-          TEST_USE_CASE, 1, absl::Now(), absl::nullopt);
+          TEST_USE_CASE, 1, absl::Now(), std::nullopt);
   EXPECT_EQ(request.status().code(), absl::StatusCode::kFailedPrecondition);
   EXPECT_THAT(request.status().message(),
               testing::HasSubstr("Public Key request is already created."));
@@ -113,7 +113,7 @@ TEST_F(AnonymousTokensPublicKeysGetClientTest,
        PublicKeyGetClientInvalidUseCaseRequest) {
   absl::StatusOr<AnonymousTokensPublicKeysGetRequest> request =
       client_->CreateAnonymousTokensPublicKeysGetRequest(
-          ANONYMOUS_TOKENS_USE_CASE_UNDEFINED, 0, absl::Now(), absl::nullopt);
+          ANONYMOUS_TOKENS_USE_CASE_UNDEFINED, 0, absl::Now(), std::nullopt);
   EXPECT_EQ(request.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(request.status().message(),
               testing::HasSubstr("Use case must be defined."));
@@ -123,7 +123,7 @@ TEST_F(AnonymousTokensPublicKeysGetClientTest,
        PublicKeyGetClientInvalidKeyVersionRequest) {
   absl::StatusOr<AnonymousTokensPublicKeysGetRequest> request =
       client_->CreateAnonymousTokensPublicKeysGetRequest(
-          TEST_USE_CASE, -1, absl::Now(), absl::nullopt);
+          TEST_USE_CASE, -1, absl::Now(), std::nullopt);
   EXPECT_EQ(request.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(
       request.status().message(),
@@ -180,7 +180,7 @@ TEST_F(AnonymousTokensPublicKeysGetClientTest,
        CreateAnonymousTokensPublicKeysGetRequestWithNoExpiryTime) {
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(
       auto request, client_->CreateAnonymousTokensPublicKeysGetRequest(
-                        TEST_USE_CASE, 0, start_time_, absl::nullopt));
+                        TEST_USE_CASE, 0, start_time_, std::nullopt));
 
   EXPECT_EQ(request.use_case(), AnonymousTokensUseCase_Name(TEST_USE_CASE));
   EXPECT_EQ(request.key_version(), 0u);
@@ -524,7 +524,7 @@ TEST_F(AnonymousTokensPublicKeysGetClientTest,
        KeyWithExpirationTimeReturnedButIndefinitelyValidKeyWasRequested) {
   ASSERT_TRUE(client_
                   ->CreateAnonymousTokensPublicKeysGetRequest(
-                      TEST_USE_CASE, 0, start_time_, absl::nullopt)
+                      TEST_USE_CASE, 0, start_time_, std::nullopt)
                   .ok());
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(auto response, SimpleGetResponse());
 
@@ -659,7 +659,7 @@ TEST_F(AnonymousTokensPublicKeysGetClientTest,
        ProcessPublicKeyGetResponseNoExpiry) {
   ASSERT_TRUE(client_
                   ->CreateAnonymousTokensPublicKeysGetRequest(
-                      TEST_USE_CASE, 1, start_time_, absl::nullopt)
+                      TEST_USE_CASE, 1, start_time_, std::nullopt)
                   .ok());
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(auto single_key_resp, SimpleGetResponse());
   single_key_resp.mutable_rsa_public_keys(0)->clear_expiration_time();

--- a/anonymous_tokens/cpp/privacy_pass/BUILD
+++ b/anonymous_tokens/cpp/privacy_pass/BUILD
@@ -113,6 +113,36 @@ cc_test(
 )
 
 cc_library(
+    name = "athm_token_encodings_utils",
+    srcs = [
+        "athm_token_encodings_utils.cc",
+    ],
+    hdrs = [
+        "athm_token_encodings_utils.h",
+    ],
+    deps = [
+        "//anonymous_tokens/cpp/shared:status_utils",
+        "@boringssl//:ssl",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "athm_token_encodings_utils_test",
+    srcs = [
+        "athm_token_encodings_utils_test.cc",
+    ],
+    deps = [
+        ":athm_token_encodings_utils",
+        "//anonymous_tokens/cpp/testing:utils",
+        "@com_github_google_googletest//:gtest_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
     name = "athm_token_encodings",
     srcs = [
         "athm_token_encodings.cc",
@@ -121,6 +151,8 @@ cc_library(
         "athm_token_encodings.h",
     ],
     deps = [
+        ":athm_token_encodings_utils",
+        "//anonymous_tokens/cpp/shared:status_utils",
         "@boringssl//:ssl",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/anonymous_tokens/cpp/privacy_pass/athm_token_encodings.cc
+++ b/anonymous_tokens/cpp/privacy_pass/athm_token_encodings.cc
@@ -16,145 +16,38 @@
 
 #include <string>
 
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
-#include <openssl/base.h>
-#include <openssl/bytestring.h>
-#include <openssl/mem.h>
+#include "anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.h"
+#include "anonymous_tokens/cpp/shared/status_utils.h"
 
 namespace anonymous_tokens {
 
 absl::StatusOr<std::string> MarshalAthmToken(const AthmToken& token) {
-  // Main CryptoByteBuilder object cbb which will be passed to CBB_finish to
-  // finalize the output string.
-  bssl::ScopedCBB cbb;
-  // initial_capacity only serves as a hint.
-  if (!CBB_init(cbb.get(), /*initial_capacity=*/kAthmTokenTypeSizeInBytes2 +
-                               kAthmIssuerKeyIdSizeInBytes32 +
-                               kAthmTokenSizeInBytes98)) {
-    return absl::InternalError("CBB_init() failed.");
-  }
-  // Add token_type to cbb.
-  if (!CBB_add_u16(cbb.get(), token.token_type) ||
-      // Add issuer_key_id to cbb.
-      !CBB_add_bytes(
-          cbb.get(),
-          reinterpret_cast<const uint8_t*>(token.issuer_key_id.data()),
-          token.issuer_key_id.size()) ||
-      // Add token to cbb.
-      !CBB_add_bytes(cbb.get(),
-                     reinterpret_cast<const uint8_t*>(token.token.data()),
-                     token.token.size())) {
-    return absl::InvalidArgumentError(
-        "Could not construct cbb with given inputs.");
-  }
-  uint8_t* encoded_output;
-  size_t encoded_output_len;
-  if (!CBB_finish(cbb.get(), &encoded_output, &encoded_output_len)) {
-    return absl::InvalidArgumentError(
-        "Failed to generate token / token input encoding");
-  }
-  std::string encoded_output_str(reinterpret_cast<const char*>(encoded_output),
-                                 encoded_output_len);
-  // Free memory.
-  OPENSSL_free(encoded_output);
-  return encoded_output_str;
+  std::string encoded_token;
+  ANON_TOKENS_RETURN_IF_ERROR(MarshalAthmToken(token, &encoded_token));
+  return encoded_token;
 }
 
 absl::StatusOr<AthmToken> UnmarshalAthmToken(absl::string_view athm_token_str) {
   AthmToken out;
-  out.issuer_key_id.resize(kAthmIssuerKeyIdSizeInBytes32);
-  out.token.resize(kAthmTokenSizeInBytes98);
-
-  CBS cbs;
-  CBS_init(&cbs, reinterpret_cast<const uint8_t*>(athm_token_str.data()),
-           athm_token_str.size());
-  if (!CBS_get_u16(&cbs, &out.token_type)) {
-    return absl::InvalidArgumentError("failed to read token type");
-  }
-  if (out.token_type != 0xC07E) {
-    return absl::InvalidArgumentError("unsupported token type");
-  }
-  if (!CBS_copy_bytes(&cbs,
-                      reinterpret_cast<uint8_t*>(out.issuer_key_id.data()),
-                      out.issuer_key_id.size())) {
-    return absl::InvalidArgumentError("failed to read issuer_key_id");
-  }
-  if (!CBS_copy_bytes(&cbs, reinterpret_cast<uint8_t*>(out.token.data()),
-                      out.token.size())) {
-    return absl::InvalidArgumentError("failed to read token");
-  }
-  if (CBS_len(&cbs) != 0) {
-    return absl::InvalidArgumentError("token had extra bytes");
-  }
+  ANON_TOKENS_RETURN_IF_ERROR(UnmarshalAthmToken(athm_token_str, &out));
   return out;
 }
 
 absl::StatusOr<std::string> MarshalAthmTokenRequest(
     const AthmTokenRequest& athm_token_request) {
-  // Main CryptoByteBuilder object cbb which will be passed to CBB_finish to
-  // finalize the output string.
-  bssl::ScopedCBB cbb;
-  // initial_capacity only serves as a hint.
-  if (!CBB_init(cbb.get(),
-                /*initial_capacity=*/kAthmTokenTypeSizeInBytes2 +
-                    kAthmTruncatedIssuerKeyIdSizeInBytes1 +
-                    kAthmEncodedRequestSizeInBytes33)) {
-    return absl::InternalError("CBB_init() failed.");
-  }
-  // Add token_type to cbb.
-  if (!CBB_add_u16(cbb.get(), athm_token_request.token_type) ||
-      // Add truncated_token_key_id to cbb.
-      !CBB_add_u8(cbb.get(), athm_token_request.truncated_issuer_key_id) ||
-      // Add blinded_token_request string to cbb.
-      !CBB_add_bytes(cbb.get(),
-                     reinterpret_cast<const uint8_t*>(
-                         athm_token_request.encoded_request.data()),
-                     athm_token_request.encoded_request.size())) {
-    return absl::InvalidArgumentError(
-        "Could not construct cbb with given inputs.");
-  }
-
-  uint8_t* encoded_output;
-  size_t encoded_output_len;
-  if (!CBB_finish(cbb.get(), &encoded_output, &encoded_output_len)) {
-    return absl::InvalidArgumentError(
-        "Failed to generate token request encoding");
-  }
-  std::string encoded_output_str(reinterpret_cast<const char*>(encoded_output),
-                                 encoded_output_len);
-  // Free memory.
-  OPENSSL_free(encoded_output);
-  return encoded_output_str;
+  std::string encoded_token_request;
+  ANON_TOKENS_RETURN_IF_ERROR(
+      MarshalAthmTokenRequest(athm_token_request, &encoded_token_request));
+  return encoded_token_request;
 }
 
 absl::StatusOr<AthmTokenRequest> UnmarshalAthmTokenRequest(
     absl::string_view athm_token_request_str) {
   AthmTokenRequest out;
-  out.encoded_request.resize(kAthmEncodedRequestSizeInBytes33);
-  CBS cbs;
-  CBS_init(&cbs,
-           reinterpret_cast<const uint8_t*>(athm_token_request_str.data()),
-           athm_token_request_str.size());
-  if (!CBS_get_u16(&cbs, &out.token_type)) {
-    return absl::InvalidArgumentError("failed to read token type");
-  }
-  if (out.token_type != 0xC07E) {
-    return absl::InvalidArgumentError("unsupported token type");
-  }
-  if (!CBS_get_u8(&cbs, &out.truncated_issuer_key_id)) {
-    return absl::InvalidArgumentError("failed to read truncated_issuer_key_id");
-  }
-  if (!CBS_copy_bytes(&cbs,
-                      reinterpret_cast<uint8_t*>(out.encoded_request.data()),
-                      out.encoded_request.size())) {
-    return absl::InvalidArgumentError(
-        "failed to read athm_token_request.encoded_request");
-  }
-  if (CBS_len(&cbs) != 0) {
-    return absl::InvalidArgumentError("token request had extra bytes");
-  }
+  ANON_TOKENS_RETURN_IF_ERROR(
+      UnmarshalAthmTokenRequest(athm_token_request_str, &out));
   return out;
 }
 

--- a/anonymous_tokens/cpp/privacy_pass/athm_token_encodings.h
+++ b/anonymous_tokens/cpp/privacy_pass/athm_token_encodings.h
@@ -21,33 +21,9 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.h"
 
 namespace anonymous_tokens {
-
-// The structs and constants are defined using the following specification:
-// https://github.com/cathieyun/draft-athm/blob/main/draft-yun-privacypass-athm.md
-
-constexpr int kAthmEncodedRequestSizeInBytes33 = 33;
-
-constexpr int kAthmTokenSizeInBytes98 = 98;
-
-constexpr int kAthmTokenTypeSizeInBytes2 = 2;
-
-constexpr int kAthmTruncatedIssuerKeyIdSizeInBytes1 = 1;
-
-constexpr int kAthmIssuerKeyIdSizeInBytes32 = 32;
-
-struct AthmTokenRequest {
-  uint16_t token_type{0xC07E}; /* Type ATHM(P-256) */
-  uint8_t truncated_issuer_key_id;
-  std::string encoded_request;
-};
-
-struct AthmToken {
-  uint16_t token_type{0xC07E}; /* Type ATHM(P-256) */
-  std::string issuer_key_id;
-  std::string token;
-};
 
 // This methods takes in a AthmToken structure and encodes it into a string.
 absl::StatusOr<std::string> MarshalAthmToken(const AthmToken& athm_token);
@@ -68,4 +44,4 @@ absl::StatusOr<AthmTokenRequest> UnmarshalAthmTokenRequest(
 
 }  // namespace anonymous_tokens
 
-#endif  // ANONYMOUS_TOKENS_CPP_PRIVACY_PASS_TOKEN_ENCODINGS_H_
+#endif  // ANONYMOUS_TOKENS_CPP_PRIVACY_PASS_ATHM_TOKEN_ENCODINGS_H_

--- a/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_test.cc
+++ b/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_test.cc
@@ -15,6 +15,7 @@
 #include "anonymous_tokens/cpp/privacy_pass/athm_token_encodings.h"
 
 #include <string>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -25,16 +26,6 @@
 
 namespace anonymous_tokens {
 namespace {
-
-TEST(AnonymousTokensAthmTokenEncodingsTest, EmptyMarshalAthmTokenTest) {
-  AthmToken token;
-  ANON_TOKENS_ASSERT_OK_AND_ASSIGN(std::string encoded_token,
-                                   MarshalAthmToken(token));
-  std::string expected_token_encoding;
-  ASSERT_TRUE(absl::HexStringToBytes("C07E", &expected_token_encoding));
-
-  EXPECT_EQ(encoded_token, expected_token_encoding);
-}
 
 TEST(AnonymousTokensAthmTokenEncodingsTest, MarshalAndUnmarshalAthmTokenTest) {
   std::string issuer_key_id;
@@ -53,15 +44,6 @@ TEST(AnonymousTokensAthmTokenEncodingsTest, MarshalAndUnmarshalAthmTokenTest) {
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(std::string encoded_token,
                                    MarshalAthmToken(token));
 
-  std::string expected_token_encoding;
-  ASSERT_TRUE(absl::HexStringToBytes(
-      "C07Eca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd27084ed3"
-      "f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d05605686200d65"
-      "00f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129b88c"
-      "92ad61c08a9fe41629a642263e4857e428a706ba87659361",
-      &expected_token_encoding));
-  EXPECT_EQ(encoded_token, expected_token_encoding);
-
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(const AthmToken token2,
                                    UnmarshalAthmToken(encoded_token));
   EXPECT_EQ(token.token_type, token2.token_type);
@@ -69,36 +51,15 @@ TEST(AnonymousTokensAthmTokenEncodingsTest, MarshalAndUnmarshalAthmTokenTest) {
   EXPECT_EQ(token.token, token2.token);
 }
 
-TEST(AnonymousTokensAthmTokenEncodingsTest, UnmarshalAthmTokenTooShort) {
+TEST(AnonymousTokensAthmTokenEncodingsTest, UnmarshalAthmTokenErrorTest) {
   std::string short_token;
   ASSERT_TRUE(absl::HexStringToBytes("C07E5f5e466042", &short_token));
-  EXPECT_FALSE(UnmarshalAthmToken(short_token).ok());
-}
-
-TEST(AnonymousTokensAthmTokenEncodingsTest, UnmarshalAthmTokenTooLong) {
-  std::string long_token;
-  ASSERT_TRUE(absl::HexStringToBytes(
-      "C07Eca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd27084ed3"
-      "f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d05605686200d65"
-      "00f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129b88c"
-      "92ad61c08a9fe41629a642263e4857e428a706ba876593618888",
-      &long_token));
-  EXPECT_FALSE(UnmarshalAthmToken(long_token).ok());
-}
-
-TEST(AnonymousTokensAthmTokenEncodingsTest, UnmarshalAthmTokenWrongType) {
-  std::string token;
-  ASSERT_TRUE(absl::HexStringToBytes(
-      "DA7Aca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd27084ed3"
-      "f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d05605686200d65"
-      "00f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129b88c"
-      "92ad61c08a9fe41629a642263e4857e428a706ba87659361",
-      &token));
-  EXPECT_FALSE(UnmarshalAthmToken(token).ok());
+  EXPECT_EQ(UnmarshalAthmToken(short_token).status().code(),
+            absl::StatusCode::kInvalidArgument);
 }
 
 TEST(AnonymousTokensAthmTokenEncodingsTest,
-     MarshalAndUnmarshalAthmTokenRequest) {
+     MarshalAndUnmarshalAthmTokenRequestTest) {
   std::string athm_token_request;
   ASSERT_TRUE(absl::HexStringToBytes(
       "4ed3f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d0560",
@@ -109,14 +70,6 @@ TEST(AnonymousTokensAthmTokenEncodingsTest,
       .encoded_request = std::move(athm_token_request)};
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(std::string encoded_token_request,
                                    MarshalAthmTokenRequest(token_request));
-
-  std::string expected_token_request_encoding;
-  ASSERT_TRUE(
-      absl::HexStringToBytes("C07E124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
-                             "080df3efcd9693b944d0560",
-                             &expected_token_request_encoding));
-
-  EXPECT_EQ(encoded_token_request, expected_token_request_encoding);
 
   ANON_TOKENS_ASSERT_OK_AND_ASSIGN(
       AthmTokenRequest decoded_token_request,
@@ -130,7 +83,7 @@ TEST(AnonymousTokensAthmTokenEncodingsTest,
 }
 
 TEST(AnonymousTokensAthmTokenEncodingsTest,
-     UnmarshalAthmTokenRequestWrongTokenType) {
+     UnmarshalAthmTokenRequestErrorTest) {
   std::string token_request_encoding;
   ASSERT_TRUE(
       absl::HexStringToBytes("DA7A124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
@@ -142,35 +95,6 @@ TEST(AnonymousTokensAthmTokenEncodingsTest,
   EXPECT_EQ(token_request.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(token_request.status().message(),
               ::testing::HasSubstr("unsupported token type"));
-}
-
-TEST(AnonymousTokensAthmTokenEncodingsTest, UnmarshalAthmTokenRequestTooShort) {
-  std::string token_request_encoding;
-  ASSERT_TRUE(
-      absl::HexStringToBytes("C07E124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
-                             "080df3efcd9693b944d05",
-                             &token_request_encoding));
-  absl::StatusOr<AthmTokenRequest> token_request =
-      UnmarshalAthmTokenRequest(token_request_encoding);
-
-  EXPECT_EQ(token_request.status().code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_THAT(token_request.status().message(),
-              ::testing::HasSubstr(
-                  "failed to read athm_token_request.encoded_request"));
-}
-
-TEST(AnonymousTokensAthmTokenEncodingsTest, UnmarshalAthmTokenRequestTooLong) {
-  std::string token_request_encoding;
-  ASSERT_TRUE(
-      absl::HexStringToBytes("C07E124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
-                             "080df3efcd9693b944d056088",
-                             &token_request_encoding));
-  absl::StatusOr<AthmTokenRequest> token_request =
-      UnmarshalAthmTokenRequest(token_request_encoding);
-
-  EXPECT_EQ(token_request.status().code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_THAT(token_request.status().message(),
-              ::testing::HasSubstr("token request had extra bytes"));
 }
 
 }  // namespace

--- a/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.cc
+++ b/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.cc
@@ -1,0 +1,174 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.h"
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "anonymous_tokens/cpp/shared/status_utils.h"
+#include <openssl/base.h>
+#include <openssl/bytestring.h>
+#include <openssl/mem.h>
+
+namespace anonymous_tokens {
+
+absl::Status MarshalAthmToken(const AthmToken& token,
+                              std::string* encoded_token) {
+  if (encoded_token == nullptr) {
+    return absl::InvalidArgumentError("`encoded_token` cannot be null.");
+  }
+  // Main CryptoByteBuilder object cbb which will be passed to CBB_finish to
+  // finalize the output string.
+  bssl::ScopedCBB cbb;
+  // initial_capacity only serves as a hint.
+  if (!CBB_init(cbb.get(), /*initial_capacity=*/kAthmTokenTypeSizeInBytes2 +
+                               kAthmIssuerKeyIdSizeInBytes32 +
+                               kAthmTokenSizeInBytes98)) {
+    return absl::InternalError("CBB_init() failed.");
+  }
+  // Add token_type to cbb.
+  if (!CBB_add_u16(cbb.get(), token.token_type) ||
+      // Add issuer_key_id to cbb.
+      !CBB_add_bytes(
+          cbb.get(),
+          reinterpret_cast<const uint8_t*>(token.issuer_key_id.data()),
+          token.issuer_key_id.size()) ||
+      // Add token to cbb.
+      !CBB_add_bytes(cbb.get(),
+                     reinterpret_cast<const uint8_t*>(token.token.data()),
+                     token.token.size())) {
+    return absl::InvalidArgumentError(
+        "Could not construct cbb with given inputs.");
+  }
+  uint8_t* encoded_output;
+  size_t encoded_output_len;
+  if (!CBB_finish(cbb.get(), &encoded_output, &encoded_output_len)) {
+    return absl::InvalidArgumentError(
+        "Failed to generate token / token input encoding");
+  }
+  *encoded_token = std::string(reinterpret_cast<const char*>(encoded_output),
+                               encoded_output_len);
+  // Free memory.
+  OPENSSL_free(encoded_output);
+  return absl::OkStatus();
+}
+
+absl::Status UnmarshalAthmToken(absl::string_view athm_token_str,
+                                AthmToken* out) {
+  if (out == nullptr) {
+    return absl::InvalidArgumentError("`out` cannot be null.");
+  }
+  out->issuer_key_id.resize(kAthmIssuerKeyIdSizeInBytes32);
+  out->token.resize(kAthmTokenSizeInBytes98);
+
+  CBS cbs;
+  CBS_init(&cbs, reinterpret_cast<const uint8_t*>(athm_token_str.data()),
+           athm_token_str.size());
+  if (!CBS_get_u16(&cbs, &out->token_type)) {
+    return absl::InvalidArgumentError("failed to read token type");
+  }
+  if (out->token_type != 0xC07E) {
+    return absl::InvalidArgumentError("unsupported token type");
+  }
+  if (!CBS_copy_bytes(&cbs,
+                      reinterpret_cast<uint8_t*>(out->issuer_key_id.data()),
+                      out->issuer_key_id.size())) {
+    return absl::InvalidArgumentError("failed to read issuer_key_id");
+  }
+  if (!CBS_copy_bytes(&cbs, reinterpret_cast<uint8_t*>(out->token.data()),
+                      out->token.size())) {
+    return absl::InvalidArgumentError("failed to read token");
+  }
+  if (CBS_len(&cbs) != 0) {
+    return absl::InvalidArgumentError("token had extra bytes");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status MarshalAthmTokenRequest(const AthmTokenRequest& athm_token_request,
+                                     std::string* encoded_token_request) {
+  if (encoded_token_request == nullptr) {
+    return absl::InvalidArgumentError(
+        "`encoded_token_request` cannot be null.");
+  }
+  // Main CryptoByteBuilder object cbb which will be passed to CBB_finish to
+  // finalize the output string.
+  bssl::ScopedCBB cbb;
+  // initial_capacity only serves as a hint.
+  if (!CBB_init(cbb.get(),
+                /*initial_capacity=*/kAthmTokenTypeSizeInBytes2 +
+                    kAthmTruncatedIssuerKeyIdSizeInBytes1 +
+                    kAthmEncodedRequestSizeInBytes33)) {
+    return absl::InternalError("CBB_init() failed.");
+  }
+  // Add token_type to cbb.
+  if (!CBB_add_u16(cbb.get(), athm_token_request.token_type) ||
+      // Add truncated_token_key_id to cbb.
+      !CBB_add_u8(cbb.get(), athm_token_request.truncated_issuer_key_id) ||
+      // Add blinded_token_request string to cbb.
+      !CBB_add_bytes(cbb.get(),
+                     reinterpret_cast<const uint8_t*>(
+                         athm_token_request.encoded_request.data()),
+                     athm_token_request.encoded_request.size())) {
+    return absl::InvalidArgumentError(
+        "Could not construct cbb with given inputs.");
+  }
+
+  uint8_t* encoded_output;
+  size_t encoded_output_len;
+  if (!CBB_finish(cbb.get(), &encoded_output, &encoded_output_len)) {
+    return absl::InvalidArgumentError(
+        "Failed to generate token request encoding");
+  }
+  *encoded_token_request = std::string(
+      reinterpret_cast<const char*>(encoded_output), encoded_output_len);
+  // Free memory.
+  OPENSSL_free(encoded_output);
+  return absl::OkStatus();
+}
+
+absl::Status UnmarshalAthmTokenRequest(absl::string_view athm_token_request_str,
+                                       AthmTokenRequest* out) {
+  if (out == nullptr) {
+    return absl::InvalidArgumentError("`out` cannot be null.");
+  }
+  out->encoded_request.resize(kAthmEncodedRequestSizeInBytes33);
+  CBS cbs;
+  CBS_init(&cbs,
+           reinterpret_cast<const uint8_t*>(athm_token_request_str.data()),
+           athm_token_request_str.size());
+  if (!CBS_get_u16(&cbs, &out->token_type)) {
+    return absl::InvalidArgumentError("failed to read token type");
+  }
+  if (out->token_type != 0xC07E) {
+    return absl::InvalidArgumentError("unsupported token type");
+  }
+  if (!CBS_get_u8(&cbs, &out->truncated_issuer_key_id)) {
+    return absl::InvalidArgumentError("failed to read truncated_issuer_key_id");
+  }
+  if (!CBS_copy_bytes(&cbs,
+                      reinterpret_cast<uint8_t*>(out->encoded_request.data()),
+                      out->encoded_request.size())) {
+    return absl::InvalidArgumentError(
+        "failed to read athm_token_request.encoded_request");
+  }
+  if (CBS_len(&cbs) != 0) {
+    return absl::InvalidArgumentError("token request had extra bytes");
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace anonymous_tokens

--- a/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.h
+++ b/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.h
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ANONYMOUS_TOKENS_CPP_PRIVACY_PASS_ATHM_TOKEN_ENCODINGS_UTILS_H_
+#define ANONYMOUS_TOKENS_CPP_PRIVACY_PASS_ATHM_TOKEN_ENCODINGS_UTILS_H_
+
+#include <stdint.h>
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "anonymous_tokens/cpp/shared/status_utils.h"
+
+namespace anonymous_tokens {
+
+// The structs and constants are defined using the following specification:
+// https://github.com/cathieyun/draft-athm/blob/main/draft-yun-privacypass-athm.md
+
+constexpr int kAthmEncodedRequestSizeInBytes33 = 33;
+
+constexpr int kAthmTokenSizeInBytes98 = 98;
+
+constexpr int kAthmTokenTypeSizeInBytes2 = 2;
+
+constexpr int kAthmTruncatedIssuerKeyIdSizeInBytes1 = 1;
+
+constexpr int kAthmIssuerKeyIdSizeInBytes32 = 32;
+
+struct AthmTokenRequest {
+  uint16_t token_type{0xC07E}; /* Type ATHM(P-256) */
+  uint8_t truncated_issuer_key_id;
+  std::string encoded_request;
+};
+
+struct AthmToken {
+  uint16_t token_type{0xC07E}; /* Type ATHM(P-256) */
+  std::string issuer_key_id;
+  std::string token;
+};
+
+// Encodes an AthmToken structure into a string `encoded_token`.
+absl::Status MarshalAthmToken(const AthmToken& token,
+                              std::string* encoded_token);
+
+// Decodes an encoded AthmToken string into an AthmToken struct `out`.
+absl::Status UnmarshalAthmToken(absl::string_view athm_token_str,
+                                AthmToken* out);
+
+// Encodes an AthmTokenRequest structure into a string `encoded_token_request`.
+absl::Status MarshalAthmTokenRequest(const AthmTokenRequest& athm_token_request,
+                                     std::string* encoded_token_request);
+
+// Decodes an encoded AthmTokenRequest string into an AthmTokenRequest struct
+// `out`.
+absl::Status UnmarshalAthmTokenRequest(absl::string_view athm_token_request_str,
+                                       AthmTokenRequest* out);
+
+}  // namespace anonymous_tokens
+
+#endif  // ANONYMOUS_TOKENS_CPP_PRIVACY_PASS_ATHM_TOKEN_ENCODINGS_UTILS_H_

--- a/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils_test.cc
+++ b/anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils_test.cc
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "anonymous_tokens/cpp/privacy_pass/athm_token_encodings_utils.h"
+
+#include <string>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/strings/escaping.h"
+#include "anonymous_tokens/cpp/testing/utils.h"
+
+namespace anonymous_tokens {
+namespace {
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest, EmptyMarshalAthmTokenTest) {
+  AthmToken token;
+  std::string encoded_token;
+  EXPECT_TRUE(MarshalAthmToken(token, &encoded_token).ok());
+  std::string expected_token_encoding;
+  ASSERT_TRUE(absl::HexStringToBytes("C07E", &expected_token_encoding));
+
+  EXPECT_EQ(encoded_token, expected_token_encoding);
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest,
+     MarshalAndUnmarshalAthmTokenTest) {
+  std::string issuer_key_id;
+  ASSERT_TRUE(absl::HexStringToBytes(
+      "ca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd2708",
+      &issuer_key_id));
+  std::string token_str;
+  ASSERT_TRUE(absl::HexStringToBytes(
+      "4ed3f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d0560568620"
+      "0d6500f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129"
+      "b88c92ad61c08a9fe41629a642263e4857e428a706ba87659361",
+      &token_str));
+  AthmToken token = {/*token_type=*/0XC07E, std::move(issuer_key_id),
+                     std::move(token_str)};
+
+  std::string encoded_token;
+  EXPECT_TRUE(MarshalAthmToken(token, &encoded_token).ok());
+
+  std::string expected_token_encoding;
+  ASSERT_TRUE(absl::HexStringToBytes(
+      "C07Eca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd27084ed3"
+      "f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d05605686200d65"
+      "00f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129b88c"
+      "92ad61c08a9fe41629a642263e4857e428a706ba87659361",
+      &expected_token_encoding));
+  EXPECT_EQ(encoded_token, expected_token_encoding);
+
+  AthmToken token2;
+  EXPECT_TRUE(UnmarshalAthmToken(encoded_token, &token2).ok());
+  EXPECT_EQ(token.token_type, token2.token_type);
+  EXPECT_EQ(token.issuer_key_id, token2.issuer_key_id);
+  EXPECT_EQ(token.token, token2.token);
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest, UnmarshalAthmTokenTooShort) {
+  std::string short_token;
+  ASSERT_TRUE(absl::HexStringToBytes("C07E5f5e466042", &short_token));
+  AthmToken token;
+  EXPECT_FALSE(UnmarshalAthmToken(short_token, &token).ok());
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest, UnmarshalAthmTokenTooLong) {
+  std::string long_token;
+  ASSERT_TRUE(absl::HexStringToBytes(
+      "C07Eca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd27084ed3"
+      "f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d05605686200d65"
+      "00f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129b88c"
+      "92ad61c08a9fe41629a642263e4857e428a706ba876593618888",
+      &long_token));
+  AthmToken token;
+  EXPECT_FALSE(UnmarshalAthmToken(long_token, &token).ok());
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest, UnmarshalAthmTokenWrongType) {
+  std::string token_str;
+  ASSERT_TRUE(absl::HexStringToBytes(
+      "DA7Aca572f8982a9ca248a3056186322d93ca147266121ddeb5632c07f1f71cd27084ed3"
+      "f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d05605686200d65"
+      "00f249475737ea9246a70c3c2a1ff280663e46c792a8ae0d9a6877d1b427bbae7129b88c"
+      "92ad61c08a9fe41629a642263e4857e428a706ba87659361",
+      &token_str));
+  AthmToken token;
+  EXPECT_FALSE(UnmarshalAthmToken(token_str, &token).ok());
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest, NullptrOutputAthmTokenTest) {
+  AthmToken token;
+  EXPECT_EQ(MarshalAthmToken(token, nullptr).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(UnmarshalAthmToken("C07E", nullptr).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest,
+     MarshalAndUnmarshalAthmTokenRequest) {
+  std::string athm_token_request;
+  ASSERT_TRUE(absl::HexStringToBytes(
+      "4ed3f2a25ec528543d9a83c850d12b3036b518fafec080df3efcd9693b944d0560",
+      &athm_token_request));
+  AthmTokenRequest token_request{
+      .token_type = 0xC07E,
+      .truncated_issuer_key_id = 0x12,
+      .encoded_request = std::move(athm_token_request)};
+  std::string encoded_token_request;
+  EXPECT_TRUE(
+      MarshalAthmTokenRequest(token_request, &encoded_token_request).ok());
+
+  std::string expected_token_request_encoding;
+  ASSERT_TRUE(
+      absl::HexStringToBytes("C07E124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
+                             "080df3efcd9693b944d0560",
+                             &expected_token_request_encoding));
+
+  EXPECT_EQ(encoded_token_request, expected_token_request_encoding);
+
+  AthmTokenRequest decoded_token_request;
+  EXPECT_TRUE(
+      UnmarshalAthmTokenRequest(encoded_token_request, &decoded_token_request)
+          .ok());
+
+  EXPECT_EQ(decoded_token_request.token_type, token_request.token_type);
+  EXPECT_EQ(decoded_token_request.truncated_issuer_key_id,
+            token_request.truncated_issuer_key_id);
+  EXPECT_EQ(decoded_token_request.encoded_request,
+            token_request.encoded_request);
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest,
+     UnmarshalAthmTokenRequestWrongTokenType) {
+  std::string token_request_encoding;
+  ASSERT_TRUE(
+      absl::HexStringToBytes("DA7A124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
+                             "080df3efcd9693b944d0560",
+                             &token_request_encoding));
+  AthmTokenRequest token_request;
+  absl::Status status =
+      UnmarshalAthmTokenRequest(token_request_encoding, &token_request);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(status.message(), ::testing::HasSubstr("unsupported token type"));
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest,
+     UnmarshalAthmTokenRequestTooShort) {
+  std::string token_request_encoding;
+  ASSERT_TRUE(
+      absl::HexStringToBytes("C07E124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
+                             "080df3efcd9693b944d05",
+                             &token_request_encoding));
+  AthmTokenRequest token_request;
+  absl::Status status =
+      UnmarshalAthmTokenRequest(token_request_encoding, &token_request);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(status.message(),
+              ::testing::HasSubstr(
+                  "failed to read athm_token_request.encoded_request"));
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest,
+     UnmarshalAthmTokenRequestTooLong) {
+  std::string token_request_encoding;
+  ASSERT_TRUE(
+      absl::HexStringToBytes("C07E124ed3f2a25ec528543d9a83c850d12b3036b518fafec"
+                             "080df3efcd9693b944d056088",
+                             &token_request_encoding));
+  AthmTokenRequest token_request;
+  absl::Status status =
+      UnmarshalAthmTokenRequest(token_request_encoding, &token_request);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(status.message(),
+              ::testing::HasSubstr("token request had extra bytes"));
+}
+
+TEST(AnonymousTokensAthmTokenEncodingsUtilsTest,
+     NullptrOutputAthmTokenRequestTest) {
+  AthmTokenRequest token_request;
+  EXPECT_EQ(MarshalAthmTokenRequest(token_request, nullptr).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(UnmarshalAthmTokenRequest("C07E", nullptr).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+}  // namespace
+}  // namespace anonymous_tokens


### PR DESCRIPTION
absl::nullopt -> std::nullopt in some files to match the source of truth

2) refactoring athm encodings into athm encodings and encoding utils where the former now simply serves as a StatusOr wrapper on top of the utils file.