### PR TITLE
Add key ID generation to GenericPublicKey

### DIFF
--- a/athm/src/backend/boringssl.rs
+++ b/athm/src/backend/boringssl.rs
@@ -927,6 +927,12 @@ impl AthmBackend for BoringSslBackend {
         p.is_identity()
     }
 
+    fn sha256(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        hasher.finalize()
+    }
+
     fn hash_to_point(msgs: &[&[u8]], dsts: &[&[u8]]) -> Result<Self::Point, &'static str> {
         hash_to_point(msgs, dsts)
     }
@@ -1081,6 +1087,18 @@ mod tests {
         // Deterministic
         let p2 = hash_to_point(&[b"test"], &[b"DST"]).unwrap();
         assert!(bool::from(p.ct_eq(&p2)));
+    }
+
+    #[test]
+    fn test_sha256() {
+        assert_eq!(
+            sha256(b""),
+            hex!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        );
+        assert_eq!(
+            sha256(b"hello world"),
+            hex!("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+        );
     }
 
     /// Test hash_to_scalar using VOPRF test vectors from

--- a/athm/src/backend/cross_backend_test.rs
+++ b/athm/src/backend/cross_backend_test.rs
@@ -159,6 +159,34 @@ mod cross_backend_tests {
     }
 
     // -----------------------------------------------------------------------
+    // Tests: sha256
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sha256_parity() {
+        let test_cases: Vec<&[u8]> = vec![
+            b"",
+            b"test",
+            b"hello world",
+            b"a",
+            b"The quick brown fox jumps over the lazy dog",
+            &[0u8; 100],
+            &[0xff; 256],
+        ];
+
+        for input in &test_cases {
+            let rc_hash = RustCryptoBackend::sha256(input);
+            let bssl_hash = BoringSslBackend::sha256(input);
+
+            assert_eq!(
+                rc_hash, bssl_hash,
+                "sha256 mismatch for input={:?}\n  rustcrypto: {:02x?}\n  boringssl:  {:02x?}",
+                input, rc_hash, bssl_hash
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Tests: generator point
     // -----------------------------------------------------------------------
 
@@ -447,6 +475,13 @@ mod cross_backend_tests {
         let client_params = GenericParams::<C>::decode_generic(&params_bytes).unwrap();
         let client_pk = GenericPublicKey::<C>::decode_generic(&pk_bytes).unwrap();
         let client_proof = GenericPublicKeyProof::<C>::decode_generic(&proof_bytes).unwrap();
+
+        // Verify that key_id matches across backends.
+        assert_eq!(
+            pk.key_id_generic(),
+            client_pk.key_id_generic(),
+            "key_id mismatch across backends"
+        );
 
         // Verify that params encode identically on both backends.
         let mut client_params_bytes = Vec::new();

--- a/athm/src/backend/mod.rs
+++ b/athm/src/backend/mod.rs
@@ -110,6 +110,9 @@ pub trait AthmBackend: 'static + Sized {
 
     // ----- Hash functions -----
 
+    /// Computes the SHA-256 hash of `data`.
+    fn sha256(data: &[u8]) -> [u8; 32];
+
     /// Hash to a curve point (P256_XMD:SHA-256_SSWU_RO_).
     fn hash_to_point(msgs: &[&[u8]], dsts: &[&[u8]]) -> Result<Self::Point, &'static str>;
 

--- a/athm/src/backend/rustcrypto.rs
+++ b/athm/src/backend/rustcrypto.rs
@@ -29,6 +29,7 @@ use p256::elliptic_curve::{
     Field, FieldBytes, FieldBytesSize, Group, PrimeField,
 };
 use p256::{NistP256, NonZeroScalar};
+use sha2::Digest;
 
 pub use p256::ProjectivePoint as RustCryptoPoint;
 pub use p256::Scalar as RustCryptoScalar;
@@ -76,6 +77,10 @@ impl AthmBackend for RustCryptoBackend {
 
     fn point_is_identity(p: &Self::Point) -> Choice {
         p.is_identity()
+    }
+
+    fn sha256(data: &[u8]) -> [u8; 32] {
+        sha2::Sha256::digest(data).into()
     }
 
     fn hash_to_point(msgs: &[&[u8]], dsts: &[&[u8]]) -> Result<Self::Point, &'static str> {

--- a/athm/src/bin/check-test-vectors.rs
+++ b/athm/src/bin/check-test-vectors.rs
@@ -3,7 +3,6 @@ use athm::{
     TokenRequest, TokenResponse,
 };
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 #[derive(Deserialize)]
@@ -64,9 +63,7 @@ fn main() {
                     PublicKeyProof::from_hex(test_vector.output.get("public_key_proof").unwrap())
                         .unwrap();
                 assert!(athm::verify_public_key_proof(&public_key, &public_key_proof, &params));
-                let mut public_key_bytes = vec![];
-                public_key.encode(&mut public_key_bytes);
-                let expected_key_id = hex::encode(Sha256::digest(&public_key_bytes));
+                let expected_key_id = hex::encode(public_key.key_id());
                 let key_id = test_vector.output.get("key_id").unwrap();
                 assert_eq!(key_id, &expected_key_id);
                 println!("{}: OK", procedure);

--- a/athm/src/bin/generate-test-vectors.rs
+++ b/athm/src/bin/generate-test-vectors.rs
@@ -1,7 +1,6 @@
 use athm::{Encodable, Params};
 use hex;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 #[derive(Serialize)]
@@ -44,9 +43,7 @@ fn main() {
 
     // Run key_gen.
     let (private_key, public_key, public_key_proof) = athm::key_gen(&params);
-    let mut public_key_bytes = vec![];
-    public_key.encode(&mut public_key_bytes);
-    let key_id = Sha256::digest(&public_key_bytes);
+    let key_id = public_key.key_id();
     test_vectors.push(TestVector {
         procedure: "key_gen",
         args: BTreeMap::new(),

--- a/athm/src/lib.rs
+++ b/athm/src/lib.rs
@@ -296,6 +296,23 @@ impl<B: AthmBackend> GenericPublicKey<B> {
         }
         Ok(Self { big_z: big_z.unwrap(), big_c_x: big_c_x.unwrap(), big_c_y: big_c_y.unwrap() })
     }
+
+    /// Computes the key identifier (`key_id`) as the SHA-256 hash of the serialized public key.
+    ///
+    /// Per the ATHM specification (Section 4.3):
+    /// `issuer_key_id = SHA-256(Serialize(verifiedPublicKey))`
+    pub fn key_id_generic(&self) -> [u8; 32] {
+        let mut out = Vec::with_capacity(Self::encoded_size());
+        self.encode_generic(&mut out);
+        B::sha256(&out)
+    }
+}
+
+impl PublicKey {
+    /// Computes the key identifier (`key_id`) as the SHA-256 hash of the serialized public key.
+    pub fn key_id(&self) -> [u8; 32] {
+        self.key_id_generic()
+    }
 }
 
 impl Encodable for PublicKey {
@@ -1284,6 +1301,21 @@ mod tests {
         assert!(!test_point_is_identity(&public_key.big_z));
         assert!(!test_point_is_identity(&public_key.big_c_x));
         assert!(!test_point_is_identity(&public_key.big_c_y));
+    }
+
+    #[test]
+    fn test_public_key_key_id() {
+        let params = gen_test_params();
+        let (_private_key, public_key, _proof) = key_gen(&params);
+
+        let key_id_gen = public_key.key_id_generic();
+        let key_id_default = public_key.key_id();
+        assert_eq!(key_id_gen, key_id_default);
+
+        let mut pk_bytes = Vec::new();
+        public_key.encode(&mut pk_bytes);
+        let expected_key_id = DefaultBackend::sha256(&pk_bytes);
+        assert_eq!(key_id_gen, expected_key_id);
     }
 
     #[test]


### PR DESCRIPTION
Adding this to reduce the surface area of the Rust<->C++ boundary in https://source.chromium.org/chromium/chromium/src/+/main:components/private_verification_tokens/common/athm_ffi/

While we have key ID computation in the C++ side already, being able to compute it in Rust would eliminate more back-and-forth between the Crubit module and the host C++ code inside the client module and in tests. 


- Add sha256 method to AthmBackend trait.
- Implement sha256 for RustCryptoBackend and BoringSslBackend.
- Add key_id_generic on GenericPublicKey per ATHM Section 4.3.
- Update test vector binaries to use key_id_generic.
- Add unit and cross-backend tests for SHA-256 and key ID.

Assisted by Antigravity.